### PR TITLE
feat: using only the global variable interfaceImage, and removing the duplicate

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,8 +72,7 @@ function initInterfaceCarousel() {
         const current = interfaces[index];
 
         // Update content with fade effect
-        const content = document.querySelector('.interface-content');
-        const interfaceImage = document.querySelector('.mockup-content');
+        const content = document.querySelector('.interface-content'); 
         console.log("Found mockup-content:", interfaceImage);
         if (!interfaceImage) {
             console.error("mockup-content not found at updateInterface()");


### PR DESCRIPTION
Following copilot suggestion: 
- "The 'interfaceImage' variable is already declared globally and then re-declared within updateInterface; consider reusing the global variable to avoid unnecessary DOM queries and potential confusion."